### PR TITLE
Jwt token fix

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -19,5 +19,6 @@ module.exports = {
     "no-console": "off",
     "no-underscore-dangle": "off",
     "no-param-reassign": 0,
+    "no-use-before-define": "off",
   },
 };

--- a/routes/auth.js
+++ b/routes/auth.js
@@ -33,14 +33,7 @@ router.post("/register", async (req, res) => {
 
     const savedUser = await User.addUser(newUser);
 
-    const jwtData = {
-      roles: newUser.roles,
-      id: newUser._id,
-      email: newUser.email,
-      username: newUser.username,
-      displayName: newUser.displayName,
-    };
-    const token = jwt.sign(jwtData, config.secret, {
+    const token = jwt.sign(jwtData(newUser), config.secret, {
       expiresIn: 604800, // 1 week
     });
 
@@ -80,7 +73,7 @@ router.post("/login", async (req, res) => {
     const result = await User.comparePassword(password, user.password);
 
     if (result) {
-      const token = jwt.sign(user.toJSON(), config.secret, {
+      const token = jwt.sign(jwtData(user), config.secret, {
         expiresIn: 604800, // 1 week
       });
 
@@ -125,6 +118,16 @@ router.get("/test", async (req, res, next) => {
       msg: "You are unauthorized",
     });
   }
+});
+
+// Other methods
+// method that returns object which will be put into jwt token
+const jwtData = user => ({
+  roles: user.roles,
+  id: user._id,
+  email: user.email,
+  username: user.username,
+  displayName: user.displayName,
 });
 
 module.exports = router;

--- a/routes/auth.js
+++ b/routes/auth.js
@@ -33,7 +33,14 @@ router.post("/register", async (req, res) => {
 
     const savedUser = await User.addUser(newUser);
 
-    const token = jwt.sign(newUser.toJSON(), config.secret, {
+    const jwtData = {
+      roles: newUser.roles,
+      id: newUser._id,
+      email: newUser.email,
+      username: newUser.username,
+      displayName: newUser.displayName,
+    };
+    const token = jwt.sign(jwtData, config.secret, {
       expiresIn: 604800, // 1 week
     });
 


### PR DESCRIPTION
Jwt token will be made using jwt.sign method which happens for register and login endpoint.

Previously in jwt token, we were storing all details including password etc. However its not wise to send password and other important details in token since anyone can copy token and paste it on jwt.io to see its contents.

Hence this PR fixes it so that we are only sending things we need in that token. For now, this is what's being put into jwt token.

```js
{
  roles: user.roles,
  id: user._id,
  email: user.email,
  username: user.username,
  displayName: user.displayName,
}
```

