### PR TITLE
fixed token issue and refactored profile routes

### DIFF
--- a/routes/auth.js
+++ b/routes/auth.js
@@ -124,7 +124,7 @@ router.get("/test", async (req, res, next) => {
 // method that returns object which will be put into jwt token
 const jwtData = user => ({
   roles: user.roles,
-  id: user._id,
+  _id: user._id,
   email: user.email,
   username: user.username,
   displayName: user.displayName,

--- a/routes/profile.js
+++ b/routes/profile.js
@@ -48,35 +48,4 @@ router.get("/:username?", async (req, res, next) => {
   }
 });
 
-// router.get("/:username", async (req, res) => {
-//   try {
-//     const { username } = req.params;
-//     const user = await User.getUserByUsername(username);
-//     if (!user) {
-//       return res.status(404).json({
-//         success: false,
-//         msg: `User with username ${username} doesn't exist`,
-//       });
-//     }
-
-//     return res.json({
-//       success: true,
-//       info: {
-//         id: user._id,
-//         username: user.username,
-//         email: user.email,
-//         displayName: user.displayName,
-//         profileImage: user.profileImage,
-//         coverImage: user.coverImage,
-//         posts: user.posts,
-//       },
-//     });
-//   } catch (err) {
-//     return res.status(401).json({
-//       success: false,
-//       msg: "You are unauthorized",
-//     });
-//   }
-// });
-
 module.exports = router;

--- a/routes/profile.js
+++ b/routes/profile.js
@@ -4,18 +4,30 @@ const router = express.Router();
 const User = require("../models/User");
 const getAuthenticatedUser = require("./shared/authenticate");
 
-router.get("/", async (req, res, next) => {
+router.get("/:username?", async (req, res, next) => {
   try {
-    const user = await getAuthenticatedUser(req, res, next);
-    const { username } = user;
+    let username;
+    if (req.params.username) username = req.params.username;
+    else {
+      const user = await getAuthenticatedUser(req, res, next);
+      username = user.username;
+    }
+
     if (!username) {
-      return res.status(404).json({
+      return res.status(401).json({
         success: false,
         msg: "You are unauthorized",
       });
     }
 
     const dbUser = await User.getUserByUsername(username);
+    if (!dbUser) {
+      return res.status(404).json({
+        success: false,
+        msg: `User with username ${username} doesn't exist`,
+      });
+    }
+
     return res.json({
       success: true,
       info: {
@@ -36,35 +48,35 @@ router.get("/", async (req, res, next) => {
   }
 });
 
-router.get("/:username", async (req, res) => {
-  try {
-    const { username } = req.params;
-    const user = await User.getUserByUsername(username);
-    if (!user) {
-      return res.status(404).json({
-        success: false,
-        msg: `User with username ${username} doesn't exist`,
-      });
-    }
+// router.get("/:username", async (req, res) => {
+//   try {
+//     const { username } = req.params;
+//     const user = await User.getUserByUsername(username);
+//     if (!user) {
+//       return res.status(404).json({
+//         success: false,
+//         msg: `User with username ${username} doesn't exist`,
+//       });
+//     }
 
-    return res.json({
-      success: true,
-      info: {
-        id: user._id,
-        username: user.username,
-        email: user.email,
-        displayName: user.displayName,
-        profileImage: user.profileImage,
-        coverImage: user.coverImage,
-        posts: user.posts,
-      },
-    });
-  } catch (err) {
-    return res.status(401).json({
-      success: false,
-      msg: "You are unauthorized",
-    });
-  }
-});
+//     return res.json({
+//       success: true,
+//       info: {
+//         id: user._id,
+//         username: user.username,
+//         email: user.email,
+//         displayName: user.displayName,
+//         profileImage: user.profileImage,
+//         coverImage: user.coverImage,
+//         posts: user.posts,
+//       },
+//     });
+//   } catch (err) {
+//     return res.status(401).json({
+//       success: false,
+//       msg: "You are unauthorized",
+//     });
+//   }
+// });
 
 module.exports = router;

--- a/routes/shared/authenticate.js
+++ b/routes/shared/authenticate.js
@@ -8,10 +8,6 @@ module.exports = (req, res, next) =>
     passport.authenticate("jwt", { session: false }, (err, user, info) => {
       if (err || !user) {
         reject(new Error("Authentication failed: ", err));
-        // reject({
-        //   err,
-        //   user,
-        // });
       }
       user = JSON.parse(JSON.stringify(user));
       resolve(user);


### PR DESCRIPTION
#### Token issue
Passport jwt needs_id in decoded jwt token or else it will fail. We can customize this, but by default, it uses getUserById method to authenticate. Hence I changed `id` key to `_id` for it to work.

#### Profile routes refactoring
Refactored /profile and /profile/:username so that they are in a single function now