### PR TITLE
Fixed exposure of db url or other important properties

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,1 +1,3 @@
 DB_URL=mongodb://localhost:27017/sidekickdb
+JWT_SECRET=YOURSECRET
+PORT=8080

--- a/README.md
+++ b/README.md
@@ -7,15 +7,21 @@ This is the root repo for backend.
 ## Prerequisites before running
 
 - Install node and npm
+- Install yarn
 - Install mongodb and make sure its running as a service
 
 ## How to run?
 
-- Git clone this project
-- Open it in vscode or navigate to this directory from any terminal of your choice.
-- Run `npm i`
-- Goto `config/database-sample.js` and make a copy of this and change the filename to `database.js`
-- In the same `database.js` file, make sure that your mongodb url or port is right (i.e., check that `27017` is the port where your mongodb is running unless you have to replace the entire url in case your mongodb is hosted somewhere other than localhost)
-- Now go to terminal and run `npm start` and use postman to test the endpoints.
+- Git clone this project.
+- Rename `.env.example` to `.env`.
+- Run `yarn start`.
 
-**Note**: API documentations regarding endpoints, their schemas etc are coming soon.
+## Environment Configuration
+
+If you want to change the mongodb url or server port etc, follow these steps
+
+- Open `.env` file that you created in previous steps.
+- Change values that you desire.
+- Run `yarn start` again.
+
+**Note**: API documentations and info regarding their endpoints can be found in `documentation` branch of this repo.

--- a/app.js
+++ b/app.js
@@ -1,3 +1,4 @@
+require("dotenv").config();
 const express = require("express");
 
 const app = express();
@@ -5,31 +6,11 @@ const app = express();
 const volleyball = require("volleyball");
 const cors = require("cors");
 const passport = require("passport");
-// Previous db connection
-// const mongoose = require("mongoose");
-// const config = require("./config/database");
+
 const connectDB = require("./config/database");
 
 // Connect Database
 connectDB();
-
-// Previous db connection
-// // Connecting to database
-// mongoose.connect(config.database, {
-//   useCreateIndex: true,
-//   useFindAndModify: false,
-//   useNewUrlParser: true,
-// });
-
-// // On database connection
-// mongoose.connection.on("connected", () => {
-//   console.log(`Connected to database ${config.database}`);
-// });
-
-// // On database error
-// mongoose.connection.on("error", err => {
-//   console.log(`Database error ${err}`);
-// });
 
 // HTTP logger & Express built-in middleware that does job of body-parser.
 app.use(volleyball);

--- a/config/database.js
+++ b/config/database.js
@@ -1,8 +1,7 @@
 const mongoose = require("mongoose");
-// Import config package and get db URI from default.json
-const config = require("config");
+const props = require("./properties");
 
-const db = config.get("mongoURI");
+const db = props.DB_URL;
 
 const connectDB = async () => {
   try {
@@ -19,13 +18,3 @@ const connectDB = async () => {
 };
 
 module.exports = connectDB;
-
-// Previous db connection
-// const databaseURL =
-//   process.env.DB_URL || "mongodb://localhost:27017/sidekickdb";
-
-// module.exports = {
-//   database: databaseURL,
-//   // Needed for passportjs
-//   secret: "yoursecret",
-// };

--- a/config/default.json
+++ b/config/default.json
@@ -1,4 +1,0 @@
-{
-    "mongoURI": "mongodb+srv://osd-user:123@main-88myw.mongodb.net/test?retryWrites=true&w=majority",
-    "jwtSecret": "yoursecret"
-}

--- a/config/passport.js
+++ b/config/passport.js
@@ -1,9 +1,9 @@
 const JwtStrategy = require("passport-jwt").Strategy;
 const { ExtractJwt } = require("passport-jwt");
-const config = require("config");
 const User = require("../models/User");
+const props = require("../config/properties");
 
-const secret = config.get("jwtSecret");
+const secret = props.JWT_SECRET;
 
 module.exports = passport => {
   const opts = {};

--- a/config/properties.js
+++ b/config/properties.js
@@ -1,0 +1,5 @@
+module.exports = {
+  DB_URL: process.env.DB_URL || "mongodb://localhost:27017/sidekickdb",
+  JWT_SECRET: process.env.JWT_SECRET || "YOURSECRET",
+  PORT: process.env.PORT || 8080,
+};

--- a/index.js
+++ b/index.js
@@ -1,10 +1,11 @@
 // Configure dotenv
 require("dotenv").config();
+const props = require("./config/properties");
 // Express App
 const app = require("./app");
 
 // Port Number
-const port = process.env.PORT || 8080;
+const port = props.PORT;
 
 // Start Server
 app.listen(port, () => {

--- a/package.json
+++ b/package.json
@@ -24,7 +24,6 @@
     "babel-cli": "^6.26.0",
     "babel-preset-env": "^1.7.0",
     "bcryptjs": "^2.4.3",
-    "config": "^3.2.2",
     "cors": "^2.8.5",
     "dotenv": "^8.0.0",
     "express": "^4.17.1",

--- a/routes/auth.js
+++ b/routes/auth.js
@@ -3,11 +3,9 @@ const express = require("express");
 const router = express.Router();
 const jwt = require("jsonwebtoken");
 const _ = require("lodash");
-// Previous db connection
-// const config = require("../config/database");
-const config = require("config");
+const props = require("../config/properties");
 
-const secret = config.get("jwtSecret");
+const secret = props.JWT_SECRET;
 const User = require("../models/User");
 const getAuthenticatedUser = require("./shared/authenticate");
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1539,13 +1539,6 @@ concat-map@0.0.1:
   resolved "https://registry.yarnpkg.com/concat-map/-/concat-map-0.0.1.tgz#d8a96bd77fd68df7793a73036a3ba0d5405d477b"
   integrity sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=
 
-config@^3.2.2:
-  version "3.2.2"
-  resolved "https://registry.yarnpkg.com/config/-/config-3.2.2.tgz#c7d31bb2a9d30013a905ff420101e3b1ba58eead"
-  integrity sha512-rOsfIOAcG82AWouK4/vBS/OKz3UPl2T/kP0irExmXJJOoWg2CmdfPLdx56bCoMUMFNh+7soQkQWCUC8DyemiwQ==
-  dependencies:
-    json5 "^1.0.1"
-
 configstore@^3.0.0:
   version "3.1.2"
   resolved "https://registry.yarnpkg.com/configstore/-/configstore-3.1.2.tgz#c6f25defaeef26df12dd33414b001fe81a543f8f"
@@ -3659,13 +3652,6 @@ json5@^0.5.1:
   version "0.5.1"
   resolved "https://registry.yarnpkg.com/json5/-/json5-0.5.1.tgz#1eade7acc012034ad84e2396767ead9fa5495821"
   integrity sha1-Hq3nrMASA0rYTiOWdn6tn6VJWCE=
-
-json5@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/json5/-/json5-1.0.1.tgz#779fb0018604fa854eacbf6252180d83543e3dbe"
-  integrity sha512-aKS4WQjPenRxiQsC93MNfjx+nbF4PAdYzmd/1JIj8HYzqfbu86beTuNgXDzPknWk0n0uARlyewZo4s++ES36Ow==
-  dependencies:
-    minimist "^1.2.0"
 
 json5@^2.1.0:
   version "2.1.0"


### PR DESCRIPTION
Since we were using `dotenv` package, I removed config package. From now on, all secured properties will be passed as environment variables. For example, the mongodb uri will be in `.env` file. 

1) I added a sample `.env.example` file which looks like this:

```js
DB_URL=mongodb://localhost:27017/sidekickdb
JWT_SECRET=YOURSECRET
PORT=8080
```

2) You have to change these values in production. In travis, I will add these as env variables along with production mongodb url. Also the filename should be .env. For further instructions on how to run it, look at the updated `README` file.
3) If you want to use any property, you have to look at `properties.js` file which is in `config` folder. It looks like this:

```js
module.exports = {
  DB_URL: process.env.DB_URL || "mongodb://localhost:27017/sidekickdb",
  JWT_SECRET: process.env.JWT_SECRET || "YOURSECRET",
  PORT: process.env.PORT || 8080,
};
```

4) We need this file so that our app doesn't crash in case these environment variables are not passed at the start of this node application.
5) If you want to use a variable, say `PORT`, you can use it like this

```js
const props = require("./config/properties");
const port = props.PORT;
// Start Server
app.listen(port, () => {
  console.log(`Server started on port ${port}`);
});

```
6) I have also updated the `README` to reflect this.